### PR TITLE
Fix-jsx-runtime-edge-cases

### DIFF
--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -1,5 +1,11 @@
 # esbuild-plugin-react18
 
+## 0.2.1
+
+### Patch Changes
+
+- Handle edgecase where jsx import ends with ',' in place of ';'
+
 ## 0.2.0
 
 ### Minor Changes

--- a/lib/package.json
+++ b/lib/package.json
@@ -2,7 +2,7 @@
   "name": "esbuild-plugin-react18",
   "author": "Mayank Kumar Chaudhari <https://mayank-chaudhari.vercel.app>",
   "private": false,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Unlock the Potential of React Server Components! Harness the power of an ESBuild plugin designed for crafting libraries compatible with RSC (React18 Server Components).",
   "license": "MPL-2.0",
   "main": "./dist/index.js",

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -125,9 +125,9 @@ function replaceBuild(buildReplacePattern: ReplacePattern, result: BuildResult) 
 
 const useClientRegExp = /^(["']use strict["'];)?["']use client["'];?/i;
 const useServerRegExp = /^(["']use strict["'];)?["']use server["'];?/i;
-const jsxImportRegExp = /(var |,)?[a-zA-Z_$][\w$]*=require\("react\/jsx-runtime"\);?/g;
+const jsxImportRegExp = /(var |,)?[a-zA-Z_$][\w$]*=require\("react\/jsx-runtime"\)[;,]?/g;
 const regExp2replace2GetVar0 = /(var |,)/;
-const regExp2replace2GetVar = /[=]require\(['"]react\/jsx-runtime['"]\);?/;
+const regExp2replace2GetVar = /[=]require\(['"]react\/jsx-runtime['"]\)[;,]?/;
 
 function onEndCallBack(result: BuildResult, options: React18PluginOptions, write?: boolean) {
   /** remove empty file imports */

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -161,7 +161,9 @@ function onEndCallBack(result: BuildResult, options: React18PluginOptions, write
             .replace(regExp2replace2GetVar, "")
             .replace(regExp2replace2GetVar0, "");
           for (let index = 1; index < jsxMatches.length; index++) {
-            txt = txt.replace(jsxMatches[index], "");
+            const token = jsxMatches[index];
+            const toReplace = token.match(/^,.*,$/) ? token.slice(1) : token;
+            txt = txt.replace(toReplace, "");
             const v1 = jsxMatches[index]
               .replace(regExp2replace2GetVar, "")
               .replace(regExp2replace2GetVar0, "");

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -162,7 +162,7 @@ function onEndCallBack(result: BuildResult, options: React18PluginOptions, write
             .replace(regExp2replace2GetVar0, "");
           for (let index = 1; index < jsxMatches.length; index++) {
             const token = jsxMatches[index];
-            const toReplace = token.match(/^,.*,$/) ? token.slice(1) : token;
+            const toReplace = /^,.*,$/.test(token) ? token.slice(1) : token;
             txt = txt.replace(toReplace, "");
             const v1 = jsxMatches[index]
               .replace(regExp2replace2GetVar, "")


### PR DESCRIPTION
Handle edgecase where jsx import starts and/or ends with ',' in place of ';'